### PR TITLE
Embedded media hack

### DIFF
--- a/gltf-converter.py
+++ b/gltf-converter.py
@@ -9,6 +9,8 @@ argv = sys.argv
 argv = argv[argv.index("--") + 1:]
 inputFile = argv[0]
 outputFile = argv[1]
+
+# Hack to deal with embedded FBX media not loading
 tempscene = '/tmp/temp.blend'
 
 inputFilename, inputFileExtension = os.path.splitext(inputFile)
@@ -20,14 +22,15 @@ def convert(extension):
         bpy.ops.wm.collada_import(filepath=inputFile)
     elif extension == ".fbx":
         bpy.ops.import_scene.fbx(filepath=inputFile)
+        
+        # Hack to deal with embedded FBX media not loading
+        bpy.ops.wm.save_mainfile(filepath=tempscene)
+        bpy.ops.wm.open_mainfile(filepath=tempscene)
     elif extension == ".obj":
         bpy.ops.import_scene.obj(filepath=inputFile)
     else:
         sys.exit('.blend, .dae, .fbx, .obj are supported')
     
-    # Hack to deal with embedded FBX media not loading
-    bpy.ops.wm.save_mainfile(filepath=tempscene)
-    bpy.ops.wm.open_mainfile(filepath=tempscene)
     bpy.ops.export_scene.gltf(filepath=outputFile)
 
 convert(inputFileExtension)

--- a/gltf-converter.py
+++ b/gltf-converter.py
@@ -9,6 +9,7 @@ argv = sys.argv
 argv = argv[argv.index("--") + 1:]
 inputFile = argv[0]
 outputFile = argv[1]
+tempscene = '/tmp/temp.blend'
 
 inputFilename, inputFileExtension = os.path.splitext(inputFile)
 

--- a/gltf-converter.py
+++ b/gltf-converter.py
@@ -24,6 +24,9 @@ def convert(extension):
     else:
         sys.exit('.blend, .dae, .fbx, .obj are supported')
     
+    # Hack to deal with embedded FBX media not loading
+    bpy.ops.wm.save_mainfile(filepath=tempscene)
+    bpy.ops.wm.open_mainfile(filepath=tempscene)
     bpy.ops.export_scene.gltf(filepath=outputFile)
 
 convert(inputFileExtension)


### PR DESCRIPTION
Not sure if you ran into this, but I found that when FBX media is embedded the glTF export fails to export textures. When I import interactively the texture comes in pink until I click on the model. The only work around I found was to save the scene then reload.

Its hacky, but I figured I'd share it incase it's helpful for you. 